### PR TITLE
Make email regex more flexible

### DIFF
--- a/unpywall/utils.py
+++ b/unpywall/utils.py
@@ -55,7 +55,7 @@ class UnpywallCredentials:
         """
 
         # from https://stackoverflow.com/a/43937713/12580727
-        email_regex = r'^[\w\.\+\-]+\@[\w]+\.[a-z]{2,3}$'
+        email_regex = r'^[\w\.\+\-]+\@[\w\.\-]+$'
 
         if email is None:
             raise ValueError(('An email address is required in order'


### PR DESCRIPTION
This new regex allows me@long.chain.of.subdomains; firstname@secondname.name and kimpark@실례.테스트

I'm not entirely sure there is any need to validate the email in the first place. Isn't that more up to unpaywall themselves?